### PR TITLE
Fix batch training padding mismatch handling

### DIFF
--- a/docs/批量训练与动态掩码.md
+++ b/docs/批量训练与动态掩码.md
@@ -170,6 +170,23 @@ let sequences = vec![
 - 减少内存占用：(3 × 4) vs (3 × 128)
 - 减少计算量：节省 (128 - 4) / 128 = 96.9% 的浪费计算
 
+### 1.1 真实长度切片（避免 PAD 参与梯度）
+
+**关键点**：虽然我们用 PAD 把序列对齐，但训练时**不能**把 PAD 当成真实 token。
+
+在 `train_monitored_batch` 中，每个样本会根据 `attention_mask` 计算真实长度：
+
+```text
+real_len = count(attention_mask == 1.0)
+input  = tokens[0..real_len]      // 只保留真实 token
+target = tokens[1..real_len]      // 右移一位做 teacher forcing
+```
+
+**这样做的好处**：
+- ✅ logits 的时间步数与 target 长度一致
+- ✅ 反向传播梯度不会被 PAD 干扰
+- ✅ 更符合“教育用途”的直觉：只学习真实序列
+
 ### 2. 数据分桶 (Bucketing)
 
 **策略**：将长度相近的序列分组到同一批次，进一步减少填充开销。
@@ -195,22 +212,20 @@ let loader = BatchLoader::new(
 
 ### 3. 注意力掩码 (Attention Mask)
 
-**作用**：标记真实 token 和 PAD token，确保 PAD 不参与梯度计算。
+**作用**：标记真实 token 和 PAD token，帮助我们“知道哪些位置是有效的”。
 
-**实现**：
-```rust
-// 在训练中应用掩码
-for s in 0..sample_grad.nrows() {
-    if input_batch.attention_mask[[b, s]] < 0.5 {
-        // PAD 位置，梯度清零
-        sample_grad.row_mut(s).fill(0.0);
-    }
-}
+在当前实现中，我们使用 attention_mask 来计算真实长度，然后**直接切片掉 PAD**：
+
+```text
+real_len = count(attention_mask == 1.0)
+input  = tokens[0..real_len]
+target = tokens[1..real_len]
 ```
 
 **重要性**：
-- ✅ 防止 PAD 影响模型学习
-- ✅ 确保损失只计算在真实 token 上
+- ✅ 训练只关注真实 token
+- ✅ 避免 logits 与 target 的长度不一致
+- ✅ 让教学逻辑更直观：PAD 只是对齐，不参与学习
 - ✅ 提升模型质量
 
 ## 性能对比

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1146,11 +1146,39 @@ impl LLM {
                 }
 
                 // 前向传播（批量）- 使用循环对每个样本单独处理
-                let mut batch_outputs = Vec::with_capacity(input_batch.batch_size);
+                //
+                // 注意：input_batch 中包含 PAD 位置，但 targets 是基于真实长度构建的。
+                // 如果直接用整个 input_batch 前向传播，会导致：
+                // 1) logits 行数 > target 长度
+                // 2) 反向传播梯度与目标长度不匹配
+                //
+                // 因此我们在每个样本内，根据 attention_mask 计算真实长度，
+                // 只取真实 token 做前向与反向传播。
+                let mut batch_outputs: Vec<Option<Array2<f32>>> =
+                    Vec::with_capacity(input_batch.batch_size);
+                let mut batch_targets = Vec::with_capacity(input_batch.batch_size);
 
                 for b in 0..input_batch.batch_size {
+                    // 通过 attention_mask 计算真实长度（去除 PAD）
+                    let real_len = input_batch
+                        .attention_mask
+                        .row(b)
+                        .iter()
+                        .filter(|&&x| x > 0.0)
+                        .count();
+
+                    if real_len == 0 {
+                        batch_outputs.push(None);
+                        batch_targets.push(Vec::new());
+                        continue;
+                    }
+
                     let sample_tokens = input_batch.tokens.row(b);
-                    let sample_ids: Vec<usize> = sample_tokens.to_vec();
+                    let sample_ids: Vec<usize> = sample_tokens
+                        .iter()
+                        .take(real_len)
+                        .copied()
+                        .collect();
 
                     // 单样本前向传播
                     let mut input: Array2<f32> = Array2::zeros((1, sample_ids.len()));
@@ -1165,34 +1193,42 @@ impl LLM {
                         input = layer.forward(&input);
                     }
 
-                    batch_outputs.push(input);
+                    batch_outputs.push(Some(input));
+                    batch_targets.push(targets.get(b).cloned().unwrap_or_default());
                 }
 
                 // 计算损失和反向传播（对每个样本）
                 let mut batch_loss = 0.0;
 
-                for (b, logits) in batch_outputs.iter().enumerate() {
-                    if b >= targets.len() || targets[b].is_empty() {
+                for (b, maybe_logits) in batch_outputs.iter().enumerate() {
+                    let Some(logits) = maybe_logits else {
+                        continue;
+                    };
+
+                    let target_ids = &batch_targets[b];
+                    if target_ids.is_empty() {
                         continue;
                     }
 
                     let log_probs = log_softmax(logits);
 
+                    // 安全检查：logits 的时间步数应与 target 长度一致
+                    if log_probs.nrows() != target_ids.len() {
+                        eprintln!(
+                            "⚠️  跳过异常样本：logits步数({}) != target长度({})",
+                            log_probs.nrows(),
+                            target_ids.len()
+                        );
+                        continue;
+                    }
+
                     // 只计算非 PAD 位置的损失
-                    let target_ids = &targets[b];
                     let loss = Self::cross_entropy_from_log_probs(&log_probs, target_ids);
                     batch_loss += loss;
 
                     // 计算梯度
                     let probs = log_probs.mapv(|x| x.exp());
                     let mut sample_grad = Self::compute_gradients_step(&probs, target_ids);
-
-                    // 应用注意力掩码到梯度（将PAD位置梯度清零）
-                    for s in 0..sample_grad.nrows() {
-                        if input_batch.attention_mask[[b, s]] < 0.5 {
-                            sample_grad.row_mut(s).fill(0.0);
-                        }
-                    }
 
                     total_grad_norm += Self::compute_grad_norm(&sample_grad);
                     Self::clip_gradients(&mut sample_grad, 1.0);


### PR DESCRIPTION
### Motivation

- Batch training used padded `Batch` inputs while `create_training_batches` produced `targets` based on real token lengths, causing logits/target length mismatches and incorrect gradient application in `train_monitored_batch`.
- Improve clarity for this educational project by documenting the per-sample real-length slicing approach so learners understand why PAD tokens must not participate in training.

### Description

- In `src/llm.rs` `train_monitored_batch` compute per-sample `real_len` from `input_batch.attention_mask` and slice `input` tokens to `tokens[0..real_len]` so forward/backward operate only on real tokens, collecting per-sample `batch_targets` accordingly.
- Add a safety check to skip malformed samples when `log_probs.nrows() != target_ids.len()` and avoid crashing or applying mismatched gradients.
- Remove the previous approach of zeroing gradients by PAD positions because samples are now sliced to exclude PAD before gradient computation.
- Update `docs/批量训练与动态掩码.md` to explain the real-length slicing rule and why PAD must not participate in gradient computation.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6968db36c0888321807fa87b91a70afa)